### PR TITLE
[Bug] Tree-Shaking is not working properly #230 (Minor Updates) #235

### DIFF
--- a/lib/src/helpers/environment.ts
+++ b/lib/src/helpers/environment.ts
@@ -211,7 +211,6 @@ export function getHistory(): History | null {
  * @group Environment
  * @returns True if you are
  */
-/*#__NO_SIDE_EFFECTS__*/
 export function isNode(): boolean {
     !_isNode && (_isNode = safeGetLazy(() => !!(process && (process.versions||{}).node), false))
 


### PR DESCRIPTION
- By tagging isNode() as no side-effects (which is doesn't have) causes rollup to agressively remove it from a non-node build, which results in bundles that don't work for all environments.
  - So untagging