### PR TITLE
Revert "Bump puppeteer from 22.15.0 to 23.4.0 (#318)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -196,7 +196,7 @@
         "karma-typescript": "^5.5.4",
         "mocha": "^10.7.0",
         "nyc": "^17.0.0",
-        "puppeteer": "^23.4.0",
+        "puppeteer": "^22.13.1",
         "rollup": "^4.14.1",
         "rollup-plugin-cleanup": "^3.2.1",
         "rollup-plugin-istanbul": "^5.0.0",


### PR DESCRIPTION
This reverts commit 1fedb77171ef65db263a5da9e9384767ddd516c6.