### PR TITLE
Add skipLibCheck to TypeDoc compiler options

### DIFF
--- a/typedoc.json
+++ b/typedoc.json
@@ -22,7 +22,8 @@
     "githubPages": true,
     "gitRevision": "main",
     "compilerOptions": {
-        "stripInternal": true
+        "stripInternal": true,
+        "skipLibCheck": true
     },
     "blockTags": [
         "@defaultValue",


### PR DESCRIPTION
Added 'skipLibCheck' option to compilerOptions.