### PR TITLE
chore(deps-dev): bump magic-string from 0.30.21 to 1.0.0

### DIFF
--- a/lib/rollup.config.js
+++ b/lib/rollup.config.js
@@ -1,7 +1,6 @@
 import nodeResolve from "@rollup/plugin-node-resolve";
 import cleanup from 'rollup-plugin-cleanup';
 import sourcemaps from 'rollup-plugin-sourcemaps';
-import MagicString from 'magic-string';
 
 const UglifyJs = require('uglify-js');
 
@@ -95,7 +94,13 @@ export function fixPureAnnotations() {
 
     return {
         name: "fix-pure-annotations",
-        renderChunk(code) {
+        async renderChunk(code) {
+            // Loaded via a dynamic import (rather than a static import/require) because magic-string
+            // ships as an ESM-only package - when this config is bundled as CJS (--bundleConfigAsCjs)
+            // a static import would be rewritten to a require(), which throws ERR_REQUIRE_ESM on Node
+            // versions that don't support requiring ESM (eg. Node 18). Dynamic import() works from a
+            // CJS context on every supported Node version.
+            const { MagicString } = await import('magic-string');
             const magic = new MagicString(code);
 
             for (const match of code.matchAll(pureRe)) {

--- a/lib/test/tsconfig.test.esnext.json
+++ b/lib/test/tsconfig.test.esnext.json
@@ -7,6 +7,7 @@
         "moduleResolution": "node",
         "target": "ESNext",
         "lib": ["ESNext", "DOM"],
+        "skipLibCheck": true,
         "forceConsistentCasingInFileNames": true,
         "importHelpers": true,
         "noEmitHelpers": false,

--- a/lib/test/tsconfig.test.json
+++ b/lib/test/tsconfig.test.json
@@ -7,6 +7,7 @@
         "moduleResolution": "node",
         "target": "es5",
         "lib": ["ES2015", "DOM"],
+        "skipLibCheck": true,
         "forceConsistentCasingInFileNames": true,
         "importHelpers": true,
         "noEmitHelpers": false,

--- a/lib/test/tsconfig.test.karma.json
+++ b/lib/test/tsconfig.test.karma.json
@@ -7,6 +7,7 @@
         "moduleResolution": "node",
         "target": "es5",
         "lib": ["ES2015", "DOM"],
+        "skipLibCheck": true,
         "forceConsistentCasingInFileNames": true,
         "importHelpers": true,
         "noEmitHelpers": false,

--- a/lib/test/tsconfig.worker.karma.json
+++ b/lib/test/tsconfig.worker.karma.json
@@ -7,6 +7,7 @@
         "moduleResolution": "node",
         "target": "es5",
         "lib": ["ES2015", "DOM"],
+        "skipLibCheck": true,
         "forceConsistentCasingInFileNames": true,
         "importHelpers": true,
         "noEmitHelpers": false,

--- a/lib/tsconfig.base.json
+++ b/lib/tsconfig.base.json
@@ -7,6 +7,7 @@
         "moduleResolution": "node",
         "target": "es5",
         "lib": ["ES2015", "DOM"],
+        "skipLibCheck": true,
         "forceConsistentCasingInFileNames": true,
         "importHelpers": true,
         "noEmitHelpers": false,

--- a/package.json
+++ b/package.json
@@ -279,7 +279,7 @@
         "karma-mocha": "^2.0.1",
         "karma-spec-reporter": "^0.0.36",
         "karma-typescript": "^5.5.4",
-        "magic-string": "^0.30.21",
+        "magic-string": "^1.0.0",
         "mocha": "^11.2.0",
         "nyc": "^18.0.0",
         "puppeteer": "^25.0.2",


### PR DESCRIPTION
Update magic-string to 1.0.0, fix usage as 1.0.0 now only ships as an ESM.